### PR TITLE
Correct furigana for "402" in Ch.2-4

### DIFF
--- a/stories/2_04_drive.html
+++ b/stories/2_04_drive.html
@@ -606,7 +606,7 @@ A<span class="particle">から</span>B<span class="particle">まで</span><ruby>
 <br>
 <ruby>東<rt>とう</rt></ruby><ruby>京<rt>きょう</rt></ruby><span class="particle">の</span><ruby>地<rt>ち</rt></ruby><ruby>下<rt>か</rt></ruby><ruby>鉄<rt>てつ</rt></ruby><span class="particle">の</span><ruby>長<rt>なが</rt></ruby>さ<span class="particle">は</span><ruby>304<rt>さんびゃくよん</rt></ruby><ruby>km<rt>キロ</rt></ruby>
 <br>
-ロンドン<span class="particle">の</span><ruby>地<rt>ち</rt></ruby><ruby>下<rt>か</rt></ruby><ruby>鉄<rt>てつ</rt></ruby><span class="particle">の</span><ruby>長<rt>なが</rt></ruby>さ<span class="particle">は</span><ruby>402<rt>よんひゃく</rt></ruby><ruby>km<rt>キロ</rt></ruby>
+ロンドン<span class="particle">の</span><ruby>地<rt>ち</rt></ruby><ruby>下<rt>か</rt></ruby><ruby>鉄<rt>てつ</rt></ruby><span class="particle">の</span><ruby>長<rt>なが</rt></ruby>さ<span class="particle">は</span><ruby>402<rt>よんひゃくに</rt></ruby><ruby>km<rt>キロ</rt></ruby>
 </p>
 </div>
 


### PR DESCRIPTION
This commit corrects furigana for the word "402" in the phrase "ロンドンの地下鉄の長さは４０２ｋｍ" in story 2-4 by changing the furigana from 「よんひゃく」(400) to 「よんひゃくに」(402).

Before:
https://i.imgur.com/H84161D.png

After:
https://i.imgur.com/LOuh9cA.png